### PR TITLE
feat: cambiado proveedor de analytics a posthog

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
 	"dependencies": {
 		"@splidejs/splide-extension-auto-scroll": "^0.5.3",
 		"@splidejs/svelte-splide": "^0.2.9",
-		"@vercel/analytics": "^1.2.2",
 		"@vercel/speed-insights": "^1.0.10",
 		"bits-ui": "^0.9.9",
 		"clsx": "^2.1.0",
@@ -43,6 +42,7 @@
 		"lucide-svelte": "^0.292.0",
 		"mode-watcher": "^0.1.2",
 		"postgres": "^3.4.4",
+		"posthog-js": "^1.142.1",
 		"svelte-sonner": "^0.3.21",
 		"sveltekit-superforms": "^1.13.4",
 		"tailwind-merge": "^2.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       '@splidejs/svelte-splide':
         specifier: ^0.2.9
         version: 0.2.9
-      '@vercel/analytics':
-        specifier: ^1.2.2
-        version: 1.2.2
       '@vercel/speed-insights':
         specifier: ^1.0.10
         version: 1.0.10(@sveltejs/kit@1.30.4(svelte@4.2.12)(vite@4.5.3))(svelte@4.2.12)
@@ -44,6 +41,9 @@ importers:
       postgres:
         specifier: ^3.4.4
         version: 3.4.4
+      posthog-js:
+        specifier: ^1.142.1
+        version: 1.142.1
       svelte-sonner:
         specifier: ^0.3.21
         version: 0.3.21(svelte@4.2.12)
@@ -589,17 +589,6 @@ packages:
   '@types/pug@2.0.10':
     resolution: {integrity: sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==}
 
-  '@vercel/analytics@1.2.2':
-    resolution: {integrity: sha512-X0rctVWkQV1e5Y300ehVNqpOfSOufo7ieA5PIdna8yX/U7Vjz0GFsGf4qvAhxV02uQ2CVt7GYcrFfddXXK2Y4A==}
-    peerDependencies:
-      next: '>= 13'
-      react: ^18 || ^19
-    peerDependenciesMeta:
-      next:
-        optional: true
-      react:
-        optional: true
-
   '@vercel/speed-insights@1.0.10':
     resolution: {integrity: sha512-4uzdKB0RW6Ff2FkzshzjZ+RlJfLPxgm/00i0XXgxfMPhwnnsk92YgtqsxT9OcPLdJUyVU1DqFlSWWjIQMPkh0g==}
     peerDependencies:
@@ -1034,6 +1023,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}
@@ -1516,6 +1508,12 @@ packages:
     resolution: {integrity: sha512-IbyN+9KslkqcXa8AO9fxpk97PA4pzewvpi2B3Dwy9u4zpV32QicaEdgmF3eSQUzdRk7ttDHQejNgAEr4XoeH4A==}
     engines: {node: '>=12'}
 
+  posthog-js@1.142.1:
+    resolution: {integrity: sha512-yqeWTWitlb0sCaH5v6s7UJ+pPspzf/lkzPaSE5pMMXRM2i2KNsMoZEAZqbPCW8fQ8QL6lHs6d8PLjHrvbR288w==}
+
+  preact@10.22.0:
+    resolution: {integrity: sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==}
+
   prettier-plugin-svelte@2.10.1:
     resolution: {integrity: sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==}
     peerDependencies:
@@ -1645,9 +1643,6 @@ packages:
     resolution: {integrity: sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==}
     engines: {node: '>=10'}
     hasBin: true
-
-  server-only@0.0.1:
-    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-cookie-parser@2.6.0:
     resolution: {integrity: sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==}
@@ -1944,6 +1939,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-vitals@4.2.0:
+    resolution: {integrity: sha512-ohj72kbtVWCpKYMxcbJ+xaOBV3En76hW47j52dG+tEGG36LZQgfFw5yHl9xyjmosy3XUMn8d/GBUAy4YPM839w==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2365,10 +2363,6 @@ snapshots:
 
   '@types/pug@2.0.10': {}
 
-  '@vercel/analytics@1.2.2':
-    dependencies:
-      server-only: 0.0.1
-
   '@vercel/speed-insights@1.0.10(@sveltejs/kit@1.30.4(svelte@4.2.12)(vite@4.5.3))(svelte@4.2.12)':
     optionalDependencies:
       '@sveltejs/kit': 1.30.4(svelte@4.2.12)(vite@4.5.3)
@@ -2778,6 +2772,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.4.8: {}
 
   fill-range@7.0.1:
     dependencies:
@@ -3199,6 +3195,14 @@ snapshots:
 
   postgres@3.4.4: {}
 
+  posthog-js@1.142.1:
+    dependencies:
+      fflate: 0.4.8
+      preact: 10.22.0
+      web-vitals: 4.2.0
+
+  preact@10.22.0: {}
+
   prettier-plugin-svelte@2.10.1(prettier@2.8.8)(svelte@4.2.12):
     dependencies:
       prettier: 2.8.8
@@ -3281,8 +3285,6 @@ snapshots:
   semver@7.6.0:
     dependencies:
       lru-cache: 6.0.0
-
-  server-only@0.0.1: {}
 
   set-cookie-parser@2.6.0: {}
 
@@ -3579,6 +3581,8 @@ snapshots:
       defaults: 1.0.4
 
   web-streams-polyfill@3.3.3: {}
+
+  web-vitals@4.2.0: {}
 
   which@2.0.2:
     dependencies:

--- a/src/lib/zod/schema.ts
+++ b/src/lib/zod/schema.ts
@@ -18,7 +18,7 @@ export default z
 		["responde-mails"]: campoNumerico,
 		["comentario"]: z.string(),
 		["cuatrimestre"]: z.string().optional(),
-		["cf-turnstile-response"]: z.string(),
+		["cf-turnstile-response"]: z.string()
 	})
 	.refine((data) => (data.comentario.length > 0 ? data.cuatrimestre : true), {
 		message: "Cuatrimestre requerido",

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,14 +1,16 @@
 import { browser, dev } from "$app/environment";
-import { env } from "$env/dynamic/private";
+import { env } from "$env/dynamic/public";
 import { injectSpeedInsights } from "@vercel/speed-insights/sveltekit";
 import posthog from "posthog-js";
 
 export const load = async () => {
 	if (!dev && browser) {
-		posthog.init(env.POSTHOG_PROJECT_API_KEY, {
-			api_host: "https://us.i.posthog.com",
-			person_profiles: "never"
-		});
+		if (env.PUBLIC_POSTHOG_PROJECT_API_KEY) {
+			posthog.init(env.PUBLIC_POSTHOG_PROJECT_API_KEY, {
+				api_host: "https://us.i.posthog.com",
+				person_profiles: "never"
+			});
+		}
 		injectSpeedInsights();
 	}
 };

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,6 +1,14 @@
-import { dev } from "$app/environment";
-import { inject } from "@vercel/analytics";
+import { browser, dev } from "$app/environment";
+import { env } from "$env/dynamic/private";
 import { injectSpeedInsights } from "@vercel/speed-insights/sveltekit";
+import posthog from "posthog-js";
 
-inject({ mode: dev ? "development" : "production" });
-injectSpeedInsights();
+export const load = async () => {
+	if (!dev && browser) {
+		posthog.init(env.POSTHOG_PROJECT_API_KEY, {
+			api_host: "https://us.i.posthog.com",
+			person_profiles: "never"
+		});
+		injectSpeedInsights();
+	}
+};

--- a/src/routes/docentes/[codigoDocente]/+page.server.ts
+++ b/src/routes/docentes/[codigoDocente]/+page.server.ts
@@ -1,3 +1,4 @@
+import { TURNSTILE_SECRET_KEY } from "$env/static/private";
 import db from "$lib/db";
 import {
 	calificacion,
@@ -16,7 +17,6 @@ import { message, setError, superValidate } from "sveltekit-superforms/server";
 
 import type { PageServerLoad } from "./$types";
 import type { Actions } from "./$types";
-import { TURNSTILE_SECRET_KEY } from "$env/static/private";
 
 export const load: PageServerLoad = async ({ params }) => {
 	let docentes;
@@ -83,7 +83,7 @@ export const actions: Actions = {
 
 		const { success } = await validateToken(
 			form.data["cf-turnstile-response"],
-			TURNSTILE_SECRET_KEY,
+			TURNSTILE_SECRET_KEY
 		);
 
 		if (!success) {


### PR DESCRIPTION
Se cambió el proveedor de Analytics a Posthog. Todavía falta limpiar un poco el código de inicialización del cliente cuando se carga la página para que esto sea opcional, igual que para los speed insights de Vercel). El único tracking que se hace es el de visita, totalmente anónimo, sin sesiones ni nada por el estilo, solo es para saber cuánta gente visita el sitio, cuales son las materias y cátedras más visitadas, y de qué parte del mundo visitan.